### PR TITLE
fix: backpressure in pipeStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 const assert = require('assert')
+const util = require('util')
+const stream = require('stream')
+const pipeline = util.promisify(stream.pipeline)
 
 function noop () {}
 
@@ -11,10 +14,7 @@ function isStream (value) {
 }
 
 async function pipeStream (iterator, stream) {
-  for await (let chunk of iterator) {
-    stream.write(chunk)
-  }
-  stream.end()
+  await pipeline(Readable.from(iterator), stream)
 }
 
 function pipe (source, target) {


### PR DESCRIPTION
- `pipeStream` was not taking backpressure into consideration.
- `pipeStream` was not waiting for the write to finish or error.

Thanks for the talk at NodeConf! Love the concept.

This can be further optimized to avoid adding/removing the listeners but would increase complexity.